### PR TITLE
Update interval for --watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Note: Data retrieved or sent on behalf of the client is not shown in the statist
 
 *You're welcome to contribute!*
 - Option for choosing logfile. `/var/log/syslog` by default.
-- Option for choosing interval speed for `--watch`.
 
 **Known issues:**
 - ppp-debugging mode logs every single transmitted packet (pptpd issue)

--- a/src/pptpd-monitor.py
+++ b/src/pptpd-monitor.py
@@ -271,21 +271,28 @@ if __name__ == "__main__":
   # pptpd will log messages in here if debug is enabled (/etc/ppp/pptpd-options)
   logfile   = "/var/log/syslog"
   logrotate = False
+  seconds = 1.0
 
   if '--help' in sys.argv or '-h' in sys.argv:
     print 'pptpd-monitor.py [OPTIONS]\n', \
           '\n', \
           '  -h,--help      Show help\n', \
           '  --watch        Continuously update\n', \
+          '  -n <sec>       Update every n seconds', \
           '  --rotate       Include logrotated files (*.gz)'
     sys.exit(0)
-
+  
   if '--rotate' in sys.argv:
     logrotate = True
     
   monitor = Monitor(logfile, logrotate)
 
   if '--watch' in sys.argv:
-    monitor.monitor(interval=1)
+    if '-n' in sys.argv:
+      try:
+        seconds = float(sys.argv[sys.argv.index('-n') + 1])
+      except ValueError:
+        print 'Non-parseable parameter found after -n, falling back to default'
+    monitor.monitor(interval = seconds)
   else:
     monitor.monitor()


### PR DESCRIPTION
As per your request in the README, here's an addition of the update interval period option for the `--watch` option. Invoked with the `-n` key, as in `watch(1)`.

P.S. Maybe my code style is a little different from yours. I'll take the time to read the PEP8 document, but until then, please point out any style mismatches you may encounter.