### PR TITLE
Adding argparse argument parsing and converting to Python 3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Simply run the script:
 And you'll get output similar to this:
 
     PPTPD Client Statistics
-    
+
     Username                #       TX       RX        Remote IP         Local IP   Int      CTX      CRX    Duration
        None              0/61  585.4MB   94.8MB           (None)   (192.168.0.10)  None     0.0b     0.0b
        john               0/6  111.8MB   29.9MB    (100.0.0.179)   (192.168.0.11)  None     0.0b     0.0b
@@ -57,7 +57,7 @@ Note: Data retrieved or sent on behalf of the client is not shown in the statist
 **Missing features**
 
 *You're welcome to contribute!*
-- Option for choosing interval speed for `--watch`.
+- [ ]
 
 **Known issues:**
 - ppp-debugging mode logs every single transmitted packet (pptpd issue)

--- a/src/pptpd-monitor.py
+++ b/src/pptpd-monitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import re, subprocess
 from datetime import datetime
@@ -64,7 +64,7 @@ class Monitor:
     sessionlist  = self.get_sessions()
     userstats    = self.get_userstats(sessionlist)
     fstring      = self.format_userstats(userstats)
-    print fstring,
+    print(fstring, end=' ')
 
     if interval is 0:
       return
@@ -74,8 +74,8 @@ class Monitor:
       self.update_sessions(self.activesessions, sessionlist)
       userstats = self.get_userstats(sessionlist)
       # Clear previous stats
-      print (fstring.count('\n') * '\033[1A') + len(fstring.split('\n')[0])*' ' + '\r',
-      print self.format_userstats(userstats),
+      print((fstring.count('\n') * '\033[1A') + len(fstring.split('\n')[0])*' ' + '\r', end=' ')
+      print(self.format_userstats(userstats), end=' ')
       time.sleep(interval)
 
   def get_sessions(self):
@@ -93,9 +93,9 @@ class Monitor:
       if logfile_data:
         logfile_data.close()
 
-      print "Reading %s" % logfile,
+      print("Reading %s" % logfile, end=' ')
       sys.stdout.flush()
-      print "\r" + " " * (8+len(logfile)) + "\r",
+      print("\r" + " " * (8+len(logfile)) + "\r", end=' ')
       try:
         if ".gz" in logfile:
           logfile_data = gzip.open(logfile, "r")
@@ -106,10 +106,10 @@ class Monitor:
           self.process_line(line, activesessions, sessionlist)
       except IOError:
         if os.path.exists(logfile):
-          print 'Failed to read file ' + logfile + ', insufficient permissions?'
+          print('Failed to read file ' + logfile + ', insufficient permissions?')
           sys.exit(1) # error, so non-zero return code
         else:
-          print 'Failed to read file ' + logfile + ", file doesn't exist?"
+          print('Failed to read file ' + logfile + ", file doesn't exist?")
           sys.exit(1) # error, so non-zero return code
       self.lastfile = logfile_data
       return sessionlist

--- a/src/pptpd-monitor.py
+++ b/src/pptpd-monitor.py
@@ -4,7 +4,13 @@ import re, subprocess
 from datetime import datetime
 
 import glob, gzip, sys, os, time
+import argparse
 
+parser = argparse.ArgumentParser(description='Monitor the PPTP server.')
+parser.add_argument('-w','--watch',action='store_true',help='monitor continuously')
+parser.add_argument('-d','--delay',type=float,help='the interval for value monitoring, has no effect if --watch is not present')
+parser.add_argument('-f','--file',type=argparse.FileType('r'),default=None)
+parser.add_argument('-r','--rotate',action='store_true',help='also include logrotated (*.gz) files')
 
 # Convert bytes to human readable format
 def sizeof_fmt(num):
@@ -22,7 +28,7 @@ def getInterfaceTotals(interface):
   command  = "ifconfig " + interface, "r"
   process  = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=DEVNULL, shell=True)
   result   = process.communicate()
-  
+
   r_ipconfig = re.compile(r"RX bytes:(\d+) .+  TX bytes:(\d+)")
   for line in result[0].split('\n'):
     m_ipconfig = r_ipconfig.search(line)
@@ -44,7 +50,7 @@ class Monitor:
   r_ppp_remoteip4       = re.compile(r"remote IP address (\d+\.\d+\.\d+\.\d+)")
   r_ppp_localip4        = re.compile(r"local IP address (\d+\.\d+\.\d+\.\d+)")
   r_ppp_exit            = re.compile(r"Exit.")
-  
+
   fmt_timestamp	= "%b %d %H:%M:%S" # Timestamp format as it appears in the logfile.
 
   def __init__(self, logfile, logrotate=True):
@@ -75,7 +81,7 @@ class Monitor:
   def get_sessions(self):
     activesessions	= self.activesessions
     sessionlist		= []
-    
+
     # Gather all session data from log
     if self.logrotate:
       logfilefilter = self.logfile + "*"
@@ -113,14 +119,14 @@ class Monitor:
     for line in self.lastfile:
       line = line.strip()
       self.process_line(line, activesessions, sessionlist)
-  
+
   def process_line(self, line, activesessions, sessionlist):
     match =  self.r_pptpd.search(line)
     if match:
       # Logdata is grouped by PID
       pid = match.group(1)
       newconnection = (pid not in activesessions)
-    
+
       activesessions.setdefault(pid, {
         "interface":      None,
         "username":       None,
@@ -134,10 +140,10 @@ class Monitor:
         "timestamp_open": None,
       })
       session = activesessions[pid]
-      
+
       if newconnection:
         sessionlist.append(session)
-    
+
       # Read remoteip4 from line and store in session
       match = self.r_ppp_remoteip4.search(line)
       if match:
@@ -155,7 +161,7 @@ class Monitor:
         session['interface']	= interface
         session['username']		= username
         session['ip4']		= ip4
-    
+
       # PPTP session closed
       m_close = self.r_ppp_close.search(line)
       if m_close:
@@ -165,7 +171,7 @@ class Monitor:
         session['tx']     += tx
         session['rx']     += rx
         session['total']  += tx + rx
-      
+
       m_exit = self.r_ppp_exit.search(line)
       if m_exit:
         # After process exits, remove PID from sessions
@@ -174,7 +180,7 @@ class Monitor:
         # and we dont want stats to be merged!
         del activesessions[pid]
 
-   
+
 
   def get_userstats(self, sessions):
     # Gather statistics per user
@@ -197,32 +203,32 @@ class Monitor:
         "interface":      None,
         "timestamp_open": None
       })
-      
+
       user['session']       = session
-      
+
       # Current Session Open
       if session['status'] == 'open':
         user['interface']     = session['interface']
         user['ip4']           = session['ip4']
         user['ppp_remoteip4'] = session['ppp_remoteip4']
-        
+
         ctx, crx = getInterfaceTotals(session['interface'])
         user['crx'] = crx
         user['ctx'] = ctx
         user['timestamp_open'] = session['timestamp_open']
-      
+
       # Totals
       user['lastseen'] =  session['timestamp_open'] # Will be overwritten by each session until the last.
       user['tx']       += session['tx']
       user['rx']       += session['rx']
       user['sessions'] += 1
       user['total']    += session['tx'] + session['rx']
-      
+
       if session['status'] == "open":
         user['sessions_open'] += 1
-    
-    
-    return users 
+
+
+    return users
 
   def format_userstats(self, users):
     fstring = ""
@@ -258,7 +264,7 @@ class Monitor:
       fstring += (str(user['sessions_open']) + "/" + str(user['sessions'])).rjust(6)
       fstring += sizeof_fmt(user['rx']).rjust(8)
       fstring += sizeof_fmt(user['tx']).rjust(8)
-      
+
       fstring += str(ip4).rjust(18)
       fstring += str(ppp_remoteip4).rjust(18)
       fstring += str(user['interface']).rjust(5)
@@ -274,31 +280,17 @@ class Monitor:
     return fstring
 
 if __name__ == "__main__":
-  # pptpd will log messages in here if debug is enabled (/etc/ppp/pptpd-options)
-  logfile   = "/var/log/syslog"
-  logrotate = False
+  args = parser.parse_args()
+  logfile   = args.file
+  if logfile is None:
+      logfile = '/var/log/syslog'
+  else:
+      logfile = logfile.file
+  logrotate = args.rotate
 
-  if '--help' in sys.argv or '-h' in sys.argv:
-    print 'pptpd-monitor.py [OPTIONS]\n', \
-          '\n', \
-          '  -h,--help      Show help\n', \
-          '  --watch        Continuously update\n', \
-          '  --log <path>   Use file at path instead of the default\n', \
-          '  --rotate       Include logrotated files (*.gz)'
-    sys.exit(0)
-
-  if '--log' in sys.argv:
-    if not os.path.isfile(sys.argv[sys.argv.index('--log') + 1]):
-      print "File doesn't exist or is not a regular file, falling back to default"
-    else:
-      logfile=sys.argv[sys.argv.index('--log') + 1]
-
-  if '--rotate' in sys.argv:
-    logrotate = True
-    
   monitor = Monitor(logfile, logrotate)
 
-  if '--watch' in sys.argv:
-    monitor.monitor(interval=1)
+  if args.watch:
+    monitor.monitor(interval=args.delay)
   else:
     monitor.monitor()


### PR DESCRIPTION
The way the argument parsing was done previously was not the correct way to do it, as it required various ad-hockery to get argument parameters. To solve that, I've diked that out and replaced it with some [`argparse`](https://docs.python.org/3/library/argparse.html) goodness.

I also converted the code to Python 3, since Python 2 is [getting retired soon](https://pythonclock.org), but feel free to leave that part out.